### PR TITLE
Editor window remove need for window class in stamps

### DIFF
--- a/src/main/java/io/wollinger/snipsniper/sceditor/SCEditorListener.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/SCEditorListener.java
@@ -146,7 +146,7 @@ public class SCEditorListener extends SnipScopeListener {
         scEditorWindow.isDirty = true;
         Graphics2D g2 = (Graphics2D)g;
         g2.setRenderingHints(scEditorWindow.getQualityHints());
-        scEditorWindow.getSelectedStamp().render(g2, scEditorWindow.getInputContainer(), true, isCensor, history.size());
+        scEditorWindow.getSelectedStamp().render(g2, scEditorWindow.getInputContainer(), scEditorWindow.getPointOnImage(new Point(input.getMouseX(), input.getMouseY())), scEditorWindow.getDifferenceFromImage(), true, isCensor, history.size());
         scEditorWindow.repaint();
         g2.dispose();
         g.dispose();

--- a/src/main/java/io/wollinger/snipsniper/sceditor/SCEditorRenderer.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/SCEditorRenderer.java
@@ -55,7 +55,7 @@ public class SCEditorRenderer extends SnipScopeRenderer {
         previewGraphics.setComposite(AlphaComposite.getInstance(AlphaComposite.CLEAR));
         previewGraphics.fillRect(0,0, preview.getWidth(), preview.getHeight());
         previewGraphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER));
-        scEditorWindow.getSelectedStamp().render(previewGraphics, scEditorWindow.getInputContainer(), false, false, -1);
+        scEditorWindow.getSelectedStamp().render(previewGraphics, scEditorWindow.getInputContainer(), scEditorWindow.getPointOnImage(new Point(scEditorWindow.getInputContainer().getMouseX(), scEditorWindow.getInputContainer().getMouseY())), scEditorWindow.getDifferenceFromImage(), false, false, -1);
         previewGraphics.dispose();
 
         g.drawImage(preview, lastRectangle.x, lastRectangle.y, lastRectangle.width, lastRectangle.height, this);

--- a/src/main/java/io/wollinger/snipsniper/sceditor/SCEditorWindow.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/SCEditorWindow.java
@@ -46,12 +46,12 @@ public class SCEditorWindow extends SnipScopeWindow {
 
         LogManager.log(id, "Loading stamps", Level.INFO);
 
-        stamps[0] = new CubeStamp(this);
-        stamps[1] = new CounterStamp(this);
-        stamps[2] = new CircleStamp(this);
-        stamps[3] = new SimpleBrush(this);
-        stamps[4] = new TextStamp(this);
-        stamps[5] = new RectangleStamp(this);
+        stamps[0] = new CubeStamp(config, this);
+        stamps[1] = new CounterStamp(config);
+        stamps[2] = new CircleStamp(config);
+        stamps[3] = new SimpleBrush(config, this);
+        stamps[4] = new TextStamp(config, this);
+        stamps[5] = new RectangleStamp(config);
 
         if(image == null)
             image = Utils.getDragPasteImage(Icons.icon_editor, "Drop image here or use CTRL + V to paste one!");

--- a/src/main/java/io/wollinger/snipsniper/sceditor/stamps/CircleStamp.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/stamps/CircleStamp.java
@@ -23,10 +23,10 @@ public class CircleStamp implements IStamp{
 
     private PBRColor color;
 
-    private final SCEditorWindow scEditorWindow;
+    private final Config config;
 
-    public CircleStamp(SCEditorWindow scEditorWindow) {
-        this.scEditorWindow = scEditorWindow;
+    public CircleStamp(Config config) {
+        this.config = config;
         reset();
     }
 
@@ -80,18 +80,16 @@ public class CircleStamp implements IStamp{
     }
 
     @Override
-    public Rectangle render(Graphics g, InputContainer input, boolean isSaveRender, boolean isCensor, int historyPoint) {
-        Double[] difference = scEditorWindow.getDifferenceFromImage();
+    public Rectangle render(Graphics g, InputContainer input, Vector2Int position, Double[] difference, boolean isSaveRender, boolean isCensor, int historyPoint) {
         int drawWidth = (int) ((double)width * difference[0]);
         int drawHeight = (int) ((double)height * difference[1]);
 
-        Vector2Int mousePos = scEditorWindow.getPointOnImage(new Point(input.getMouseX(), input.getMouseY()));
         Graphics2D g2 = (Graphics2D)g;
         Stroke oldStroke = g2.getStroke();
         g2.setStroke(new BasicStroke(thickness));
         Color oldColor = g2.getColor();
         g2.setColor(color.getColor());
-        Rectangle rectangle = new Rectangle(mousePos.getX() - drawWidth / 2, mousePos.getY() - drawHeight / 2, drawWidth, drawHeight);
+        Rectangle rectangle = new Rectangle(position.getX() - drawWidth / 2, position.getY() - drawHeight / 2, drawWidth, drawHeight);
         g2.drawOval(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         g2.setColor(oldColor);
         g2.setStroke(oldStroke);
@@ -111,7 +109,6 @@ public class CircleStamp implements IStamp{
 
     @Override
     public void reset() {
-        Config config = scEditorWindow.getConfig();
         color = new PBRColor(config.getColor("editorStampCircleDefaultColor"));
         width = config.getInt("editorStampCircleWidth");
         height = config.getInt("editorStampCircleHeight");

--- a/src/main/java/io/wollinger/snipsniper/sceditor/stamps/CounterStamp.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/stamps/CounterStamp.java
@@ -11,7 +11,7 @@ import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 
 public class CounterStamp implements IStamp{
-    private final SCEditorWindow scEditorWindow;
+    private final Config config;
 
     private int width;
     private int height;
@@ -31,8 +31,8 @@ public class CounterStamp implements IStamp{
 
     private final ArrayList<Integer> historyPoints = new ArrayList<>();
 
-    public CounterStamp(SCEditorWindow scEditorWindow) {
-        this.scEditorWindow = scEditorWindow;
+    public CounterStamp(Config config) {
+        this.config = config;
         reset();
     }
 
@@ -71,21 +71,18 @@ public class CounterStamp implements IStamp{
         }
     }
 
-    public Rectangle render(Graphics g, InputContainer input, boolean isSaveRender, boolean isCensor, int historyPoint) {
+    public Rectangle render(Graphics g, InputContainer input, Vector2Int position, Double[] difference, boolean isSaveRender, boolean isCensor, int historyPoint) {
         Rectangle drawnRectangle = null;
         if(isSaveRender && historyPoint != -1) {
             historyPoints.add(historyPoint);
         }
 
-        Vector2Int mousePos = scEditorWindow.getPointOnImage(new Point(input.getMouseX(), input.getMouseY()));
-
-        Double[] difference = scEditorWindow.getDifferenceFromImage();
         int drawWidth = (int) ((double)width * difference[0]);
         int drawHeight = (int) ((double)height * difference[1]);
 
         if(!isCensor) {
-            final int x = mousePos.getX() - drawWidth / 2;
-            final int y = mousePos.getY() - drawHeight / 2;
+            final int x = position.getX() - drawWidth / 2;
+            final int y = position.getY() - drawHeight / 2;
 
             Color oldFillColor = g.getColor();
             g.setColor(color.getColor());
@@ -102,15 +99,15 @@ public class CounterStamp implements IStamp{
             int h = (int) (drawHeight / fontSizeModifier);
             g.setFont(new Font("TimesRoman", Font.PLAIN, h));
             int w = g.getFontMetrics().stringWidth("" + count);
-            g.drawString("" + count, mousePos.getX() - w / 2, mousePos.getY() + h / 3);
+            g.drawString("" + count, position.getX() - w / 2, position.getY() + h / 3);
             g.setColor(oldColor);
 
-            if (scEditorWindow.getConfig().getBool("editorStampCounterBorderEnabled")) {
+            if (config.getBool("editorStampCounterBorderEnabled")) {
                 oldColor = g.getColor();
                 g.setColor(Color.BLACK);
                 Graphics2D g2 = (Graphics2D) g;
                 Stroke oldStroke = g2.getStroke();
-                g2.setStroke(new BasicStroke(drawHeight / scEditorWindow.getConfig().getFloat("editorStampCounterBorderModifier")));
+                g2.setStroke(new BasicStroke(drawHeight / config.getFloat("editorStampCounterBorderModifier")));
                 g2.drawOval(x, y, drawWidth, drawHeight);
                 g2.setStroke(oldStroke);
                 g2.dispose();
@@ -146,19 +143,18 @@ public class CounterStamp implements IStamp{
     @Override
     public void reset() {
         count = 1;
-        Config cfg = scEditorWindow.getConfig();
-        color = new PBRColor(cfg.getColor("editorStampCounterDefaultColor"));
-        width = cfg.getInt("editorStampCounterWidth");
-        height = cfg.getInt("editorStampCounterHeight");
+        color = new PBRColor(config.getColor("editorStampCounterDefaultColor"));
+        width = config.getInt("editorStampCounterWidth");
+        height = config.getInt("editorStampCounterHeight");
 
-        minimumWidth = cfg.getInt("editorStampCounterWidthMinimum");
-        minimumHeight = cfg.getInt("editorStampCounterHeightMinimum");
+        minimumWidth = config.getInt("editorStampCounterWidthMinimum");
+        minimumHeight = config.getInt("editorStampCounterHeightMinimum");
 
-        speedWidth = cfg.getInt("editorStampCounterWidthSpeed");
-        speedHeight = cfg.getInt("editorStampCounterHeightSpeed");
-        speed = cfg.getInt("editorStampCounterSpeed");
-        fontSizeModifier = cfg.getFloat("editorStampCounterFontSizeModifier");
-        solidColor = cfg.getBool("editorStampCounterSolidColor");
+        speedWidth = config.getInt("editorStampCounterWidthSpeed");
+        speedHeight = config.getInt("editorStampCounterHeightSpeed");
+        speed = config.getInt("editorStampCounterSpeed");
+        fontSizeModifier = config.getFloat("editorStampCounterFontSizeModifier");
+        solidColor = config.getBool("editorStampCounterSolidColor");
     }
 
     @Override

--- a/src/main/java/io/wollinger/snipsniper/sceditor/stamps/CubeStamp.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/stamps/CubeStamp.java
@@ -10,7 +10,8 @@ import java.awt.*;
 import java.awt.event.KeyEvent;
 
 public class CubeStamp implements IStamp{
-    private final SCEditorWindow editor;
+    private final Config config;
+    private final SCEditorWindow scEditorWindow;
     private int width;
     private int height;
 
@@ -21,11 +22,10 @@ public class CubeStamp implements IStamp{
     private int speedHeight;
 
     private PBRColor color;
-    private final Config config;
 
-    public CubeStamp(SCEditorWindow editor) {
-        this.editor = editor;
-        this.config = editor.getConfig();
+    public CubeStamp(Config config, SCEditorWindow scEditorWindow) {
+        this.config = config;
+        this.scEditorWindow = scEditorWindow;
         reset();
     }
 
@@ -64,25 +64,23 @@ public class CubeStamp implements IStamp{
         }
     }
 
-    public Rectangle render(Graphics g, InputContainer input, boolean isSaveRender, boolean isCensor, int historyPoint) {
+    public Rectangle render(Graphics g, InputContainer input, Vector2Int position, Double[] difference, boolean isSaveRender, boolean isCensor, int historyPoint) {
         boolean isSmartPixel = config.getBool("smartPixel");
-        Vector2Int mousePos = editor.getPointOnImage(new Point(input.getMouseX(), input.getMouseY()));
-        Double[] difference = editor.getDifferenceFromImage();
 
         int drawWidth = (int) ((double)width * difference[0]);
         int drawHeight = (int) ((double)height * difference[1]);
 
-        if(isSmartPixel && isSaveRender && !isCensor) {
-            Vector2Int pos = new Vector2Int(mousePos.getX() + drawWidth / 2, mousePos.getY() + drawHeight / 2);
+        if(isSmartPixel && isSaveRender && !isCensor && scEditorWindow != null) {
+            Vector2Int pos = new Vector2Int(position.getX() + drawWidth / 2, position.getY() + drawHeight / 2);
             Vector2Int size = new Vector2Int(-drawWidth, -drawHeight);
 
             for (int y = 0; y < -size.getY(); y++) {
                 for (int x = 0; x < -size.getX(); x++) {
                     int posX = pos.getX() - x;
                     int posY = pos.getY() - y;
-                    if(posX >= 0 && posY >= 0 && posX < editor.getImage().getWidth() && posY < editor.getImage().getHeight()) {
+                    if(posX >= 0 && posY >= 0 && posX < scEditorWindow.getImage().getWidth() && posY < scEditorWindow.getImage().getHeight()) {
 
-                        Color c = new Color(editor.getImage().getRGB(posX, posY));
+                        Color c = new Color(scEditorWindow.getImage().getRGB(posX, posY));
                         int total = c.getRed() + c.getGreen() + c.getBlue();
                         int alpha = (int)((205F/765F) * total + 25);
                         Color oC = color.getColor();
@@ -96,15 +94,15 @@ public class CubeStamp implements IStamp{
             if(!isCensor)
                 g.setColor(color.getColor());
             else
-                g.setColor(editor.getCensorColor());
+                g.setColor(Color.BLACK); //TODO: Add to config
 
             if(isSmartPixel && !isCensor)
                 g.setColor(new PBRColor(color.getColor(), 150).getColor());
 
-            g.fillRect(mousePos.getX() - drawWidth / 2, mousePos.getY() - drawHeight / 2, drawWidth, drawHeight);
+            g.fillRect(position.getX() - drawWidth / 2, position.getY() - drawHeight / 2, drawWidth, drawHeight);
             g.setColor(oldColor);
         }
-        return new Rectangle(mousePos.getX() - drawWidth / 2, mousePos.getY() - drawHeight / 2, drawWidth, drawHeight);
+        return new Rectangle(position.getX() - drawWidth / 2, position.getY() - drawHeight / 2, drawWidth, drawHeight);
     }
 
     @Override

--- a/src/main/java/io/wollinger/snipsniper/sceditor/stamps/IStamp.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/stamps/IStamp.java
@@ -2,13 +2,14 @@ package io.wollinger.snipsniper.sceditor.stamps;
 
 import io.wollinger.snipsniper.utils.InputContainer;
 import io.wollinger.snipsniper.utils.PBRColor;
+import io.wollinger.snipsniper.utils.Vector2Int;
 
 import java.awt.*;
 import java.awt.event.KeyEvent;
 
 public interface IStamp {
     void update(InputContainer input, int mouseWheelDirection, KeyEvent keyEvent);
-    Rectangle render(Graphics g, InputContainer input, boolean isSaveRender, boolean isCensor, int historyPoint);
+    Rectangle render(Graphics g, InputContainer input, Vector2Int position, Double[] difference, boolean isSaveRender, boolean isCensor, int historyPoint);
     void editorUndo(int historyPoint);
 
     void mousePressedEvent(int button, boolean pressed);

--- a/src/main/java/io/wollinger/snipsniper/sceditor/stamps/RectangleStamp.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/stamps/RectangleStamp.java
@@ -1,7 +1,6 @@
 package io.wollinger.snipsniper.sceditor.stamps;
 
 import io.wollinger.snipsniper.Config;
-import io.wollinger.snipsniper.sceditor.SCEditorWindow;
 import io.wollinger.snipsniper.utils.InputContainer;
 import io.wollinger.snipsniper.utils.PBRColor;
 import io.wollinger.snipsniper.utils.Vector2Int;
@@ -10,7 +9,7 @@ import java.awt.*;
 import java.awt.event.KeyEvent;
 
 public class RectangleStamp implements IStamp {
-    private final SCEditorWindow scEditorWindow;
+    private final Config config;
 
     private int width;
     private int height;
@@ -25,8 +24,8 @@ public class RectangleStamp implements IStamp {
 
     private PBRColor color;
 
-    public RectangleStamp(SCEditorWindow scEditorWindow) {
-        this.scEditorWindow = scEditorWindow;
+    public RectangleStamp(Config config) {
+        this.config = config;
         reset();
     }
 
@@ -80,18 +79,16 @@ public class RectangleStamp implements IStamp {
     }
 
     @Override
-    public Rectangle render(Graphics g, InputContainer input, boolean isSaveRender, boolean isCensor, int historyPoint) {
-        Vector2Int mousePos = scEditorWindow.getPointOnImage(new Point(input.getMouseX(), input.getMouseY()));
+    public Rectangle render(Graphics g, InputContainer input, Vector2Int position, Double[] difference, boolean isSaveRender, boolean isCensor, int historyPoint) {
         Graphics2D g2 = (Graphics2D)g;
         Stroke oldStroke = g2.getStroke();
-        Double[] difference = scEditorWindow.getDifferenceFromImage();
         int strokeThickness = (int)(thickness*difference[0]);
         if(strokeThickness <= 0)
             strokeThickness = 1;
         g2.setStroke(new BasicStroke(strokeThickness));
         Color oldColor = g2.getColor();
         g2.setColor(color.getColor());
-        Rectangle rectangle = new Rectangle((int)(mousePos.getX() - ((double)width*difference[0]) / 2), (int)(mousePos.getY() - ((double)height*difference[1]) / 2), (int)((double)width*difference[0]), (int)((double)height*difference[1]));
+        Rectangle rectangle = new Rectangle((int)(position.getX() - ((double)width*difference[0]) / 2), (int)(position.getY() - ((double)height*difference[1]) / 2), (int)((double)width*difference[0]), (int)((double)height*difference[1]));
         g2.drawRect(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
         g2.setColor(oldColor);
         g2.setStroke(oldStroke);
@@ -109,7 +106,6 @@ public class RectangleStamp implements IStamp {
 
     @Override
     public void reset() {
-        Config config = scEditorWindow.getConfig();
         color = new PBRColor(config.getColor("editorStampRectangleDefaultColor"));
 
         width = config.getInt("editorStampRectangleWidth");

--- a/src/main/java/io/wollinger/snipsniper/sceditor/stamps/SimpleBrush.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/stamps/SimpleBrush.java
@@ -10,17 +10,17 @@ import java.awt.*;
 import java.awt.event.KeyEvent;
 
 public class SimpleBrush implements IStamp {
+    private final Config config;
     private final SCEditorWindow scEditorWindow;
 
     private int size;
     private int speed;
 
     private PBRColor color;
-    private final Config config;
 
-    public SimpleBrush(SCEditorWindow scEditorWindow) {
+    public SimpleBrush(Config config, SCEditorWindow scEditorWindow) {
+        this.config = config;
         this.scEditorWindow = scEditorWindow;
-        this.config = scEditorWindow.getConfig();
         reset();
     }
 
@@ -39,18 +39,15 @@ public class SimpleBrush implements IStamp {
     }
 
     @Override
-    public Rectangle render(Graphics g, InputContainer input, boolean isSaveRender, boolean isCensor, int historyPoint) {
-        Double[] difference = scEditorWindow.getDifferenceFromImage();
-        Vector2Int mousePos = scEditorWindow.getPointOnImage(new Point(input.getMouseX(), input.getMouseY()));
-
+    public Rectangle render(Graphics g, InputContainer input, Vector2Int position, Double[] difference, boolean isSaveRender, boolean isCensor, int historyPoint) {
         int newSize = (int) ((double)size * difference[0]);
 
         Color oldColor = g.getColor();
         g.setColor(new Color(color.getColor().getRed(), color.getColor().getGreen(), color.getColor().getBlue(), 255));
-        g.fillOval(mousePos.getX() - newSize / 2, mousePos.getY() - newSize / 2, newSize, newSize);
+        g.fillOval(position.getX() - newSize / 2, position.getY() - newSize / 2, newSize, newSize);
         g.setColor(oldColor);
 
-        if(!input.isKeyPressed(scEditorWindow.getMovementKey())) {
+        if(scEditorWindow != null && !input.isKeyPressed(scEditorWindow.getMovementKey())) {
             Vector2Int p0 = scEditorWindow.getPointOnImage(input.getMousePathPoint(0));
             Vector2Int p1 = scEditorWindow.getPointOnImage(input.getMousePathPoint(1));
 
@@ -75,7 +72,7 @@ public class SimpleBrush implements IStamp {
                 g2.dispose();
             }
         }
-        return new Rectangle(mousePos.getX() - newSize / 2, mousePos.getY() - newSize / 2, newSize, newSize);
+        return new Rectangle(position.getX() - newSize / 2, position.getY() - newSize / 2, newSize, newSize);
     }
 
     @Override

--- a/src/main/java/io/wollinger/snipsniper/sceditor/stamps/TextStamp.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/stamps/TextStamp.java
@@ -11,6 +11,8 @@ import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 
 public class TextStamp implements IStamp{
+    private final Config config;
+    private final SCEditorWindow scEditorWindow;
 
     private PBRColor color;
     private int fontSize;
@@ -20,16 +22,16 @@ public class TextStamp implements IStamp{
     private final ArrayList<Integer> nonTypeKeys = new ArrayList<>();
 
     private int fontMode = Font.PLAIN;
-    private final SCEditorWindow scEditorWindow;
 
     private TextState state = TextState.IDLE;
-    private Vector2Int position = new Vector2Int();
+    private Vector2Int cPosition = new Vector2Int();
     private Vector2Int livePosition = new Vector2Int();
     private boolean doSaveNextRender = false;
 
     enum TextState {IDLE, TYPING}
 
-    public TextStamp(SCEditorWindow scEditorWindow) {
+    public TextStamp(Config config, SCEditorWindow scEditorWindow) {
+        this.config = config;
         this.scEditorWindow = scEditorWindow;
 
         nonTypeKeys.add(KeyEvent.VK_SHIFT);
@@ -64,23 +66,26 @@ public class TextStamp implements IStamp{
     }
 
     @Override
-    public Rectangle render(Graphics g, InputContainer input, boolean isSaveRender, boolean isCensor, int historyPoint) {
+    public Rectangle render(Graphics g, InputContainer input, Vector2Int position, Double[] difference, boolean isSaveRender, boolean isCensor, int historyPoint) {
         livePosition = new Vector2Int(input.getMouseX(), input.getMouseY()); //Update method only gets called upon keypress
 
         Point pointToUseForRenderPos = new Point(input.getMouseX(), input.getMouseY());
 
         if(state == TextState.TYPING)
-            pointToUseForRenderPos = new Point(position.toPoint());
+            pointToUseForRenderPos = new Point(cPosition.toPoint());
 
         if(isSaveRender && !doSaveNextRender)
             return null;
 
-        Vector2Int renderPos = scEditorWindow.getPointOnImage(pointToUseForRenderPos);
+        Vector2Int renderPos = position;
+        if(scEditorWindow != null)
+            renderPos = scEditorWindow.getPointOnImage(pointToUseForRenderPos);
+
         String textToDraw = "Text";
         if(!text.isEmpty())
             textToDraw = text;
 
-        int drawFontSize = (int) ((double)fontSize * scEditorWindow.getDifferenceFromImage()[1]);
+        int drawFontSize = (int) ((double)fontSize * difference[1]);
 
         Font oldFont = g.getFont();
         Color oldColor = g.getColor();
@@ -89,7 +94,7 @@ public class TextStamp implements IStamp{
         g.drawString(textToDraw, renderPos.getX(), renderPos.getY());
         g.setFont(oldFont);
         g.setColor(oldColor);
-
+        
         if(isSaveRender) {
             reset();
         }
@@ -105,7 +110,7 @@ public class TextStamp implements IStamp{
     public void mousePressedEvent(int button, boolean pressed) {
         if(pressed && state == TextState.IDLE) {
             state = TextState.TYPING;
-            position = new Vector2Int(livePosition);
+            cPosition = new Vector2Int(livePosition);
         } else if(pressed && state == TextState.TYPING) {
             doSaveNextRender = true;
         }

--- a/src/main/java/io/wollinger/snipsniper/sceditor/stamps/TextStamp.java
+++ b/src/main/java/io/wollinger/snipsniper/sceditor/stamps/TextStamp.java
@@ -67,6 +67,11 @@ public class TextStamp implements IStamp{
 
     @Override
     public Rectangle render(Graphics g, InputContainer input, Vector2Int position, Double[] difference, boolean isSaveRender, boolean isCensor, int historyPoint) {
+        if(input == null) {
+            input = new InputContainer();
+            input.setMousePosition(position.getX(), position.getY());
+        }
+
         livePosition = new Vector2Int(input.getMouseX(), input.getMouseY()); //Update method only gets called upon keypress
 
         Point pointToUseForRenderPos = new Point(input.getMouseX(), input.getMouseY());
@@ -118,7 +123,6 @@ public class TextStamp implements IStamp{
 
     @Override
     public void reset() {
-        Config config = scEditorWindow.getConfig();
         text = "";
         state = TextState.IDLE;
         doSaveNextRender = false;


### PR DESCRIPTION
This was done so that we can use stamps to for example pre render a stamp with config values inside the config window.